### PR TITLE
Added notation indicator

### DIFF
--- a/InitGui.py
+++ b/InitGui.py
@@ -1,5 +1,5 @@
 
-class DrawingDimensioningWorkbench (Workbench): 
+class DrawingDimensioningWorkbench (Workbench):
     # Icon generated using by converting linearDimension.svg to xpm format using Gimp
     Icon = '''
 /* XPM */
@@ -55,13 +55,13 @@ static char * linearDimension_xpm[] = {
         DEBUG=False
         if DEBUG:
             import crudeDebugger
-        for module in ['linearDimension', 'deleteDimension', 'circularDimension', 'textAdd', 'textEdit', 'textMove','escapeDimensioning', 'angularDimension' ,'radiusDimension', 'centerLines']:
+        for module in ['linearDimension', 'deleteDimension', 'circularDimension', 'textAdd', 'textEdit', 'textMove','escapeDimensioning', 'angularDimension' ,'radiusDimension', 'centerLines', 'noteCircle']:
             if not DEBUG:
                 importlib.import_module( module )
             else:
                 crudeDebugger.printingDebugging( os.path.join(__dir__, module + '.py') )
                 importlib.import_module(  module + '_crudeDebugging')
-        commandslist = ['linearDimension', 'circularDimension', 'radiusDimension', 'angularDimension', 'DrawingDimensioning_centerLines', 'DrawingDimensioning_centerLine', 'textAddDimensioning','textEditDimensioning', 'textMoveDimensioning', 'deleteDimension', 'escapeDimensioning']
+        commandslist = ['linearDimension', 'circularDimension', 'radiusDimension', 'angularDimension', 'DrawingDimensioning_centerLines', 'DrawingDimensioning_centerLine', 'noteCircle', 'textAddDimensioning','textEditDimensioning', 'textMoveDimensioning', 'deleteDimension', 'escapeDimensioning']
         self.appendToolbar('Drawing Dimensioning', commandslist)
         FreeCADGui.addIconPath(iconPath)
         FreeCADGui.addPreferencePage( os.path.join( __dir__, 'Resources', 'ui', 'drawing_dimensioing_prefs-base.ui'),'Drawing Dimensioning' )

--- a/Resources/icons/noteCircle.svg
+++ b/Resources/icons/noteCircle.svg
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="32px"
+   height="32px"
+   id="svg3085"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="noteCircle.svg">
+  <defs
+     id="defs3087">
+    <inkscape:path-effect
+       effect="skeletal"
+       id="path-effect3066"
+       is_visible="true"
+       pattern="M 0,0 0,10 10,5 z"
+       copytype="single_stretched"
+       prop_scale="1"
+       scale_y_rel="false"
+       spacing="0"
+       normal_offset="0"
+       tang_offset="0"
+       prop_units="false"
+       vertical_pattern="false"
+       fuse_tolerance="0" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient7597">
+      <stop
+         style="stop-color:#000003;stop-opacity:1;"
+         offset="0"
+         id="stop7599" />
+      <stop
+         style="stop-color:#000003;stop-opacity:0;"
+         offset="1"
+         id="stop7601" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3893">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop3895" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop3897" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient7597"
+       id="linearGradient7603"
+       x1="15.71482"
+       y1="22.299378"
+       x2="34.136209"
+       y2="22.299378"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.627417"
+     inkscape:cx="10.958665"
+     inkscape:cy="16.013936"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:grid-bbox="true"
+     inkscape:document-units="px"
+     inkscape:window-width="1920"
+     inkscape:window-height="1030"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata3090">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer">
+    <rect
+       style="fill:#0009ff;fill-opacity:1;stroke:#0009ff;stroke-width:0.0881026;stroke-linecap:butt;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       id="rect3018-4"
+       width="0.77737933"
+       height="20.488386"
+       x="21.319294"
+       y="-6.5519562"
+       transform="matrix(0.74222964,0.67014563,-0.65263094,0.75767596,0,0)" />
+    <path
+       sodipodi:type="arc"
+       style="fill:#ffffff;stroke:#0000ff;stroke-width:2px;stroke-opacity:1"
+       id="path3038"
+       sodipodi:cx="16.020388"
+       sodipodi:cy="16.863495"
+       sodipodi:rx="8"
+       sodipodi:ry="8"
+       d="m 24.020388,16.863495 a 8,8 0 1 1 -16.0000004,0 8,8 0 1 1 16.0000004,0 z"
+       transform="matrix(1.1226462,0,0,1.0954762,-0.62568776,-4.8972227)" />
+    <!--    <path-->
+    <!--       style="fill:#0009ff;fill-opacity:1;stroke:#0009ff;stroke-width:2.0px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"-->
+    <!--       d="M 5.9890779,5.3588616 13.28103,8.3127946 12.625617,11.995401 8.4978192,12.552663 z"-->
+    <!--       id="path3062"-->
+    <!--       inkscape:connector-curvature="0" />-->
+  </g>
+</svg>

--- a/dimensionSvgConstructor.py
+++ b/dimensionSvgConstructor.py
@@ -15,14 +15,14 @@ def directionVector( A, B ):
         return (B-A)/norm(B-A)
 
 def dimensionSVG_trimLine(A,B,trimA, trimB):
-    d = directionVector( A, B) 
+    d = directionVector( A, B)
     return (A + d*trimA).tolist() + (B - d*trimB).tolist()
 
 def rotate2D( v, angle ):
     return numpy.dot( [[ cos(angle), -sin(angle)],[ sin(angle), cos(angle)]], v)
 
 def arrowHeadSVG( tipPos, d, L1, L2, W, clr='blue'):
-    d2 = numpy.dot( [[ 0, -1],[ 1, 0]], d) #same as rotate2D( d, pi/2 ) 
+    d2 = numpy.dot( [[ 0, -1],[ 1, 0]], d) #same as rotate2D( d, pi/2 )
     R = numpy.array( [d, d2]).transpose()
     p2 = numpy.dot( R, [ L1,    W/2.0 ]) + tipPos
     p3 = numpy.dot( R, [ L1+L2, 0     ]) + tipPos
@@ -52,7 +52,7 @@ def linearDimensionSVG( x1, y1, x2, y2, x3, y3, x4=None, y4=None, scale=1.0, tex
         if abs( sum( numpy.sign(d) * numpy.sign( p3- (p1+p2)/2 ))) == 0:
             return None
         textRotation = numpy.arctan( (y2 - y1)/(x2 - x1))  / numpy.pi * 180
-        #if textRotation < 
+        #if textRotation <
     else:
         return None
     A = p1 + numpy.dot(p3-p1,d)*d
@@ -129,6 +129,28 @@ def radiusDimensionSVG( center_x, center_y, radius, radialLine_x=None, radialLin
 </%s> ''' % ( svgTag, svgParms, "\n".join(XML_body), svgTag )
     return XML
 
+
+def noteCircleSVG( start_x, start_y,
+                   radialLine_x=None, radialLine_y=None,
+                   tail_x=None, tail_y=None,
+                   textFormat='R%3.3f', centerPointDia = 1, svgTag='g', svgParms='', fontSize=4,
+                   strokeWidth=0.5, dimScale=1.0, lineColor='blue', fontColor='red'):
+    XML_body = [ ]
+    if radialLine_x <> None and radialLine_y <> None:
+        XML_body.append( '<line x1="%f" y1="%f" x2="%f" y2="%f" style="stroke:%s;stroke-width:%1.2f" />' % (radialLine_x, radialLine_y, start_x, start_y, lineColor, strokeWidth) )
+        if tail_x <> None and tail_y <> None:
+            XML_body.append( '<line x1="%f" y1="%f" x2="%f" y2="%f" style="stroke:%s;stroke-width:%1.2f" />' % (radialLine_x, radialLine_y, tail_x, radialLine_y, lineColor, strokeWidth) )
+            XML_body.append(' <circle cx ="%f" cy ="%f" r="%f" stroke="%s" fill="white" /> ' % (tail_x, radialLine_y, 4.5, lineColor) )
+            notenum = 0
+            XML_body.append( '<text x="%f" y="%f" fill="%s" style="font-size:%i">%s</text>' % ( tail_x - 1.5, radialLine_y + 1.5, fontColor, fontSize, '0'))
+            XML_body.append( '<!--%s-->' % (notenum) )
+            XML_body.append( '<!--%s-->' % (textFormat) )
+    XML = '''<%s  %s >
+%s
+</%s> ''' % ( svgTag, svgParms, "\n".join(XML_body), svgTag )
+    return XML
+
+
 def lineIntersection(line1, line2):
     x1,y1 = line1[0:2]
     dx1 = line1[2] - x1
@@ -138,18 +160,18 @@ def lineIntersection(line1, line2):
     dy2 = line2[3] - y2
     # x1 + dx1*t1 = x2 + dx2*t2
     # y1 + dy1*t1 = y2 + dy2*t2
-    A = numpy.array([ 
+    A = numpy.array([
             [ dx1, -dx2 ],
             [ dy1, -dy2 ],
             ])
     b = numpy.array([ x2 - x1, y2 - y1])
     t1,t2 = numpy.linalg.solve(A,b)
-    x_int = x1 + dx1*t1 
+    x_int = x1 + dx1*t1
     y_int = y1 + dy1*t1
     #assert x1 + dx1*t1 == x2 + dx2*t2
     return x_int, y_int
 
-def angularDimensionSVG( line1, line2, x_baseline, y_baseline, x_text=None, y_text=None, textFormat='%3.1f°',  gap_datum_points = 2, dimension_line_overshoot=1, 
+def angularDimensionSVG( line1, line2, x_baseline, y_baseline, x_text=None, y_text=None, textFormat='%3.1f°',  gap_datum_points = 2, dimension_line_overshoot=1,
                          arrowL1=3, arrowL2=1, arrowW=2, svgTag='g', svgParms='', fontSize=4, strokeWidth=0.5, lineColor='blue', fontColor='red'):
     XML = []
     x_int, y_int = lineIntersection(line1, line2)
@@ -165,7 +187,7 @@ def angularDimensionSVG( line1, line2, x_baseline, y_baseline, x_text=None, y_te
     p5 = numpy.array([ x_baseline, y_baseline ])
     r_P5 = norm( p5 -p_center )
     # determine arrow position
-    def arrowPosition( d ): 
+    def arrowPosition( d ):
         cand1 = p_center + d*r_P5
         cand2 = p_center - d*r_P5
         return cand1 if norm( cand1 - p5) < norm( cand2 - p5) else cand2
@@ -187,7 +209,7 @@ def angularDimensionSVG( line1, line2, x_baseline, y_baseline, x_text=None, y_te
 
     largeArc = False # given the selection method for the arrow heads (points and line1 and line2 used for measuring the angle)
     angle_1 = arctan2( d2[1], d2[0] )
-    angle_2 = arctan2( d1[1], d1[0] ) 
+    angle_2 = arctan2( d1[1], d1[0] )
     if abs(angle_1 - angle_2) < pi: #modulo correction required, since arctan2 return [-pi, pi]
         if angle_2 < angle_1:
             angle_2 = angle_2 + 2*pi
@@ -213,7 +235,7 @@ def angularDimensionSVG( line1, line2, x_baseline, y_baseline, x_text=None, y_te
 </%s> ''' % ( svgTag, svgParms, '\n'.join(XML), svgTag )
     return XML
 
-    
+
 def _centerLineSVG( x1, y1, x2, y2, len_dot, len_dash, len_gap, start_with_half_dot=False):
     start = numpy.array( [x1, y1] )
     end = numpy.array( [x2, y2] )
@@ -222,7 +244,7 @@ def _centerLineSVG( x1, y1, x2, y2, len_dot, len_dash, len_gap, start_with_half_
     pos = start
     step = len_dot*0.5 if start_with_half_dot else len_dot
     while norm(pos - start) + 10**-6 < norm(end - start):
-        dCode = dCode + 'M %f,%f' %  (pos[0], pos[1])    
+        dCode = dCode + 'M %f,%f' %  (pos[0], pos[1])
         pos = pos + d*step
         if norm(pos - start) > norm(end - start):
             pos = end

--- a/noteCircle.py
+++ b/noteCircle.py
@@ -1,0 +1,91 @@
+
+from dimensioning import *
+from dimensioning import iconPath # not imported with * directive
+import selectionOverlay, previewDimension
+from dimensionSvgConstructor import noteCircleSVG
+
+dimensioning = DimensioningProcessTracker()
+
+def selectFun( event, referer, elementXML, elementParms, elementViewObject ):
+    x,y = elementParms['x'], elementParms['y']
+    dimensioning.point1 = x, y
+    debugPrint(2, 'note start point selected at x=%3.1f y=%3.1f' % (x,y))
+    dimensioning.dimScale = 1/elementXML.rootNode().scaling() / UnitConversionFactor()
+    dimensioning.stage = 1
+    selectionOverlay.hideSelectionGraphicsItems()
+    previewDimension.initializePreview( dimensioning.drawingVars, clickFunPreview, hoverFunPreview )
+
+def clickFunPreview( x, y ):
+    """
+    this method is called in response to a mouse click during a
+    dimensioning operation
+    """
+    if dimensioning.stage == 1:
+        dimensioning.point2 = x,y
+        debugPrint(2, 'dimension radial direction point set to x=%3.1f y=%3.1f' % (x,y))
+        dimensioning.stage = 2
+        return None, None
+    else:
+        XML = noteCircleSVG( dimensioning.point1[0], dimensioning.point1[1],
+                             dimensioning.point2[0], dimensioning.point2[1],
+                             x, y,
+                             dimScale=dimensioning.dimScale, **dimensioning.dimensionConstructorKWs)
+        return findUnusedObjectName('dim'), XML
+
+def hoverFunPreview( x, y ):
+    """
+    this method is called in when updating the screen while hovering during a
+    dimensioning operation
+    """
+    if dimensioning.stage == 1:
+        return noteCircleSVG( dimensioning.point1[0], dimensioning.point1[1],
+                              x, y,
+                              dimScale=dimensioning.dimScale, **dimensioning.svg_preview_KWs )
+    else:
+        return noteCircleSVG( dimensioning.point1[0], dimensioning.point1[1],
+                              dimensioning.point2[0], dimensioning.point2[1],
+                              x, y,
+                              dimScale=dimensioning.dimScale,**dimensioning.svg_preview_KWs )
+
+#selection variables for angular dimensioning
+maskPen =      QtGui.QPen( QtGui.QColor(0,255,0,100) )
+maskPen.setWidth(2.0)
+maskHoverPen = QtGui.QPen( QtGui.QColor(0,255,0,255) )
+maskHoverPen.setWidth(2.0)
+
+class noteCircle:
+    def Activated(self):
+        V = getDrawingPageGUIVars()
+        dimensioning.activate(V, [['centerPointDia',1.0]])
+        keywordsToBeRemoved = [ 'arrowW', 'arrowL1', 'arrowL2']
+        for k in keywordsToBeRemoved:
+            del dimensioning.dimensionConstructorKWs[k]
+            del dimensioning.svg_preview_KWs[k]
+
+        dimensioning.SVGFun = noteCircleSVG
+        maskBrush  =   QtGui.QBrush( QtGui.QColor(0,160,0,100) )
+        maskPen =      QtGui.QPen( QtGui.QColor(0,160,0,100) )
+        maskPen.setWidth(0.0)
+        maskHoverPen = QtGui.QPen( QtGui.QColor(0,255,0,255) )
+        maskHoverPen.setWidth(0.0)
+        selectionOverlay.generateSelectionGraphicsItems(
+            [obj for obj in V.page.Group  if not obj.Name.startswith('dim') and not obj.Name.startswith('center')],
+            selectFun,
+            transform = V.transform,
+            sceneToAddTo = V.graphicsScene,
+            doPoints=True, doMidPoints=True,
+            pointWid=1.0,
+            maskPen=maskPen,
+            maskHoverPen=maskHoverPen,
+            maskBrush = maskBrush
+            )
+        selectionOverlay.addProxyRectToRescaleGraphicsSelectionItems( V.graphicsScene, V.graphicsView, V.width, V.height)
+
+    def GetResources(self):
+        return {
+            'Pixmap' : os.path.join( iconPath , 'noteCircle.svg' ) ,
+            'MenuText': 'Notation',
+            'ToolTip': 'Creates a notation indicator'
+            }
+
+FreeCADGui.addCommand('noteCircle', noteCircle())

--- a/radiusDimension.py
+++ b/radiusDimension.py
@@ -29,8 +29,8 @@ def clickFunPreview( x, y ):
         return None, None
     else:
         XML = radiusDimensionSVG( dimensioning.point1[0], dimensioning.point1[1], dimensioning.radius,
-                                  dimensioning.point2[0], dimensioning.point2[1], 
-                                  dimensioning.point3[0], dimensioning.point3[1], 
+                                  dimensioning.point2[0], dimensioning.point2[1],
+                                  dimensioning.point3[0], dimensioning.point3[1],
                                   x, y, dimScale=dimensioning.dimScale,
                                   **dimensioning.dimensionConstructorKWs)
         return findUnusedObjectName('dim'), XML
@@ -39,14 +39,15 @@ def hoverFunPreview( x, y):
     if dimensioning.stage == 1:
         return radiusDimensionSVG( dimensioning.point1[0], dimensioning.point1[1], dimensioning.radius, x, y, dimScale=dimensioning.dimScale, **dimensioning.svg_preview_KWs )
     elif dimensioning.stage == 2:
-        return radiusDimensionSVG( dimensioning.point1[0], dimensioning.point1[1], dimensioning.radius, 
+        return radiusDimensionSVG( dimensioning.point1[0], dimensioning.point1[1], dimensioning.radius,
                                      dimensioning.point2[0], dimensioning.point2[1], x, y, dimScale=dimensioning.dimScale, **dimensioning.svg_preview_KWs )
-    else: 
-        return radiusDimensionSVG( dimensioning.point1[0], dimensioning.point1[1], dimensioning.radius, 
-                                     dimensioning.point2[0], dimensioning.point2[1], 
-                                     dimensioning.point3[0], dimensioning.point3[1], 
-                                     x, y, dimScale=dimensioning.dimScale,**dimensioning.svg_preview_KWs )
-    
+    else:
+        return radiusDimensionSVG( dimensioning.point1[0], dimensioning.point1[1], dimensioning.radius,
+                                     dimensioning.point2[0], dimensioning.point2[1],
+                                     dimensioning.point3[0], dimensioning.point3[1],
+                                     x, y,
+                                     dimScale=dimensioning.dimScale, **dimensioning.svg_preview_KWs )
+
 
 maskPen =      QtGui.QPen( QtGui.QColor(0,255,0,100) )
 maskPen.setWidth(2.0)
@@ -57,23 +58,23 @@ class radiusDimension:
     def Activated(self):
         V = getDrawingPageGUIVars()
         dimensioning.activate(V, [['centerPointDia',1.0]])
-        selectionOverlay.generateSelectionGraphicsItems( 
-            [obj for obj in V.page.Group  if not obj.Name.startswith('dim')], 
+        selectionOverlay.generateSelectionGraphicsItems(
+            [obj for obj in V.page.Group  if not obj.Name.startswith('dim')],
             selectFun ,
             transform = V.transform,
-            sceneToAddTo = V.graphicsScene, 
-            doCircles=True, doFittedCircles=True, 
-            maskPen=maskPen, 
-            maskHoverPen=maskHoverPen, 
+            sceneToAddTo = V.graphicsScene,
+            doCircles=True, doFittedCircles=True,
+            maskPen=maskPen,
+            maskHoverPen=maskHoverPen,
             maskBrush = QtGui.QBrush() #clear
             )
         selectionOverlay.addProxyRectToRescaleGraphicsSelectionItems( V.graphicsScene, V.graphicsView, V.width, V.height)
 
-    def GetResources(self): 
+    def GetResources(self):
         return {
-            'Pixmap' : os.path.join( iconPath , 'radiusDimension.svg' ) , 
-            'MenuText': 'Radius Dimension', 
+            'Pixmap' : os.path.join( iconPath , 'radiusDimension.svg' ) ,
+            'MenuText': 'Radius Dimension',
             'ToolTip': 'Creates a radius dimension'
-            } 
+            }
 
 FreeCADGui.addCommand('radiusDimension', radiusDimension())


### PR DESCRIPTION
This adds a notation indicator. A line with a circle on the end containing some text. This is used in drawings to mark features referred to in annotations by number. The line is constructed in two stages in the same way as a radius dimension.
![screenshot from 2015-01-14 16 13 26](https://cloud.githubusercontent.com/assets/3159692/5742205/59875ab2-9c08-11e4-8dd5-c241aefec3b4.png)
