### PR TITLE
dimensioning.py: find drawing page by label, not object name

### DIFF
--- a/dimensioning.py
+++ b/dimensioning.py
@@ -26,26 +26,42 @@ def getDrawingPageGUIVars():
     '''
     Get the FreeCAD window, graphicsScene, drawing page object, ...
     '''
+    # get the active window
     mw = QtGui.qApp.activeWindow()
     MdiArea = [c for c in mw.children() if isinstance(c,QtGui.QMdiArea)][0]
-    
+
     try:
         subWinMW = MdiArea.activeSubWindow().children()[3]
     except AttributeError:
         QtGui.QMessageBox.information( QtGui.qApp.activeWindow(), notDrawingPage_title, notDrawingPage_msg  )
-        raise ValueError, notDrawingPage_title 
-    page = App.ActiveDocument.getObject( subWinMW.objectName() )
+        raise ValueError, notDrawingPage_title
+
+    # The drawing 'page' is really a group in the model tree
+    # The objectName for the group object is not the same as the name shown in
+    # the model view, this is the 'Label' property, it *should* be unique.
+    # To find the page we are on, we get all the pages which have the same label as
+    # the current object. In theory there should therefore only be one page in the list
+    # returned by getObjectsByLabel, so we'll just take the first in the list
+    pages = App.ActiveDocument.getObjectsByLabel( subWinMW.objectName() )
+
+    # raise an error explaining that the page wasn't found if the list is empty
+    if len(pages) == 0:
+        raise ValueError, notDrawingPage_title
+
+    # get the page from the list
+    page = pages[0]
+
     try:
         graphicsView = [ c for c in subWinMW.children() if isinstance(c,QtGui.QGraphicsView)][0]
     except IndexError:
         QtGui.QMessageBox.information( QtGui.qApp.activeWindow(), notDrawingPage_title, notDrawingPage_msg  )
-        raise ValueError, notDrawingPage_title 
+        raise ValueError, notDrawingPage_title
     graphicsScene = graphicsView.scene()
     pageRect = graphicsScene.items()[0] #hope this index does not change!
     width = pageRect.rect().width()
     height = pageRect.rect().height()
     #ViewResult has an additional tranform on it [VRT].
-    #if width > 1400: #then A3 # or == 1488 in FreeCAD v 0.15 
+    #if width > 1400: #then A3 # or == 1488 in FreeCAD v 0.15
     #    VRT_scale = width / 420.0 #VRT = view result transform, where 420mm is the width of an A3 page.
     #else: #assuming A4
     #    VRT_scale = width / 297.0
@@ -91,7 +107,7 @@ class DimensioningProcessTracker:
         self.dimensionConstructorKWs['fontColor'] = getColor('fontColor',255 << 24)
         debugPrint(3, 'dimensionConstructorKWs %s' % self.dimensionConstructorKWs )
         self.svg_preview_KWs.update( self.dimensionConstructorKWs )
-        
+
 def UnitConversionFactor():
     #found using App.ParamGet("User parameter:BaseApp/Preferences").Export('/tmp/p3')
     p = App.ParamGet("User parameter:BaseApp/Preferences/Units")
@@ -109,7 +125,7 @@ def recomputeWithOutViewReset( drawingVars ):
     '''
     printGraphicsViewInfo( drawingVars )
     gV =  drawingVars.graphicsView
-    T = gV.transform() 
+    T = gV.transform()
     scale = T.m11()
     ##attempting to find centre of view
     #dx = gV.mapToScene( 0,0).x()
@@ -117,7 +133,7 @@ def recomputeWithOutViewReset( drawingVars ):
     ## now scene_x = view_x/scale + dx; so
     #centerView = [
     #    0.5*gV.width(),
-    #    0.5*gV.height(), 
+    #    0.5*gV.height(),
     #    ]
     #centerScene = gV.mapToScene( *centerView )
     #centerOn approach did not work rather using scroll bars.
@@ -134,20 +150,20 @@ def recomputeWithOutViewReset( drawingVars ):
         gV.scale( s_correction, s_correction )
 
     gV.horizontalScrollBar().setValue( h_scrollValue )
-    gV.verticalScrollBar().setValue( v_scrollValue )    
+    gV.verticalScrollBar().setValue( v_scrollValue )
     printGraphicsViewInfo( drawingVars )
 
 
 def printGraphicsViewInfo( drawingVars ):
     '''
-    A PySide.QtGui.QTransform object contains a 3 x 3 matrix. The m31 (dx ) and m32 (dy ) elements specify horizontal and vertical translation. 
-    The m11 and m22 elements specify horizontal and vertical scaling. 
-    The m21 and m12 elements specify horizontal and vertical shearing . 
+    A PySide.QtGui.QTransform object contains a 3 x 3 matrix. The m31 (dx ) and m32 (dy ) elements specify horizontal and vertical translation.
+    The m11 and m22 elements specify horizontal and vertical scaling.
+    The m21 and m12 elements specify horizontal and vertical shearing .
     And finally, the m13 and m23 elements specify horizontal and vertical projection, with m33 as an additional projection factor.
-    
-    This function was written help restore the view transform after App.ActiveDocument.recompute(); 
+
+    This function was written help restore the view transform after App.ActiveDocument.recompute();
     example of how to get T, T= preview.drawingVars.graphicsView.transform()
-    
+
     DrawingView.cpp: line134: s->setSceneRect(m_outlineItem->boundingRect().adjusted(-10, -10, 10, 10)); # s is QGraphicsScene  used for scroll bars!
     '''
     T = drawingVars.graphicsView.transform()
@@ -156,11 +172,11 @@ def printGraphicsViewInfo( drawingVars ):
     debugPrint(4,'    [ %1.2f  %1.2f  %1.2f ]' % (T.m11(), T.m12(), T.m13() ))
     debugPrint(4,'M = [ %1.2f  %1.2f  %1.2f ]' % (T.m21(), T.m22(), T.m23() ))
     debugPrint(4,'    [ %1.2f  %1.2f  %1.2f ]' % (T.m31(), T.m32(), T.m33() ))
-    
+
     #r = preview.drawingVars.graphicsView.sceneRect() #seems to be used for scroll bars, not for anything else
     #debugPrint(2,'graphicsView.sceneRect info: topLeft.x %3.2f, topLeft.y %3.2f, bottomRight.x %3.2f, bottomRight.y %3.2f' \
     #               % (r.topLeft().x(), r.topLeft().y(), r.bottomRight().x(), r.bottomRight().y() ) )
-    
+
     #T = drawingVars.graphicsView.viewportTransform()
     #sx, sy, dx, dy = T.m11(), T.m22(), T.m31(), T.m32()
     #debugPrint(2,'viewPort transform info: sx %1.2f, sy %1.2f, dx %1.2f, dy %1.2f' % (sx, sy, dx, dy) )


### PR DESCRIPTION
This pull request fixes issue #24. Previously the drawing page was located using the object Name, but the object label is the correct thing to look for.