### PR TITLE
changing PySide2.QtCore.QByteArray calls to be utf-8-encoded strings …

### DIFF
--- a/drawingDimensioning/previewDimension.py
+++ b/drawingDimensioning/previewDimension.py
@@ -57,7 +57,8 @@ def initializePreview( dimensioningProcessTracker, dimensionSvgFun, dimensionCli
         preview.SVG =  QtSvg.QGraphicsSvgItem() 
         debugPrint(3, 'creating dimPreview SVG renderer')
         preview.SVGRenderer = QtSvg.QSvgRenderer()
-        preview.SVGRenderer.load( QtCore.QByteArray( '''<svg width="%i" height="%i"> </svg>''' % (drawingVars.width, drawingVars.height) ) ) #without this something goes wrong...
+        qbytestr = '''<svg width="%i" height="%i"> </svg>''' % (drawingVars.width, drawingVars.height)
+        preview.SVGRenderer.load( QtCore.QByteArray( qbytestr.encode('utf-8') ) ) #without this something goes wrong...
         preview.SVG_initialization_width = drawingVars.width
         preview.SVG_initialization_height = drawingVars.height
         preview.SVG.setSharedRenderer( preview.SVGRenderer )
@@ -65,7 +66,8 @@ def initializePreview( dimensioningProcessTracker, dimensionSvgFun, dimensionCli
         preview.SVG.setZValue( 0.09 )
     preview.removedQtItems = False
     debugPrint(4, 'adding SVG')
-    preview.SVGRenderer.load( QtCore.QByteArray( '''<svg width="%i" height="%i"> </svg>''' % (drawingVars.width, drawingVars.height) ) )
+    qbytestr = '''<svg width="%i" height="%i"> </svg>''' % (drawingVars.width, drawingVars.height)
+    preview.SVGRenderer.load( QtCore.QByteArray( qbytestr.encode('utf-8') ) )
     preview.SVG.update()
     #preview.SVG.
     drawingVars.graphicsScene.addItem( preview.SVG )
@@ -153,7 +155,7 @@ class DimensionPreviewRect(QtGui.QGraphicsRectItem):
             if isinstance(XML, unicode_type): 
                 XML = encode_if_py2(XML)
             debugPrint(5, XML)
-            preview.SVGRenderer.load( QtCore.QByteArray( XML ) )
+            preview.SVGRenderer.load( QtCore.QByteArray( XML.encode('utf-8') ) )
             preview.SVG.update()
         except:
             App.Console.PrintError(traceback.format_exc())


### PR DESCRIPTION
…rather than Python str so it matches the signature of QByteArray.

Running FreeCAD 0.18.3 on Ubuntu 19.10 I was getting errors adding a dimension to a drawing. Error such as:
 raceback (most recent call last):
  File "/home/musinsky/.FreeCAD/Mod/FreeCAD_drawing_dimensioning/drawingDimensioning/selectionOverlay/__init__.py", line 23, in mousePressEvent
    self._onClickFun( event, self, self.elementXML, self.elementParms, self.elementViewObject )
  File "/home/musinsky/.FreeCAD/Mod/FreeCAD_drawing_dimensioning/drawingDimensioning/linearDimension.py", line 214, in selectDimensioningPoint
    previewDimension.initializePreview( d, linearDimension_points_preview, linearDimension_points_clickHandler )
  File "/home/musinsky/.FreeCAD/Mod/FreeCAD_drawing_dimensioning/drawingDimensioning/previewDimension.py", line 60, in initializePreview
    preview.SVGRenderer.load( QtCore.QByteArray( '''<svg width="%i" height="%i"> </svg>''' % (drawingVars.width, drawingVars.height) ) ) #without this something goes wrong...
TypeError: 'PySide2.QtCore.QByteArray' called with wrong argument types:
  PySide2.QtCore.QByteArray(str)
Supported signatures:
  PySide2.QtCore.QByteArray()
  PySide2.QtCore.QByteArray(bytearray)
  PySide2.QtCore.QByteArray(bytes)
  PySide2.QtCore.QByteArray(PySide2.QtCore.QByteArray)
  PySide2.QtCore.QByteArray(int, char)

By encoding each QByteArray string as utf-8, the call is now working and the dimension shows up as expected since it now matches the 'bytes' signature for QByteArray.